### PR TITLE
Generate UUID with native shared library if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # rspec failure tracking
 .rspec_status
 report.html
+*.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    rake-compiler (1.1.1)
+      rake
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.8.0)
@@ -54,6 +56,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   pry
   rake (~> 13.0)
+  rake-compiler
   rspec (~> 3.0)
   rubocop (~> 1.13.0)
   stack_trace!

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,12 @@
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rake/extensiontask"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: [:compile, :spec]
+
+Rake::ExtensionTask.new "stack_trace" do |ext|
+  ext.lib_dir = "lib/stack_trace/native_extensions"
+end

--- a/ext/stack_trace/extconf.rb
+++ b/ext/stack_trace/extconf.rb
@@ -1,0 +1,3 @@
+require "mkmf"
+
+create_makefile("stack_trace/native_extensions/stack_trace")

--- a/ext/stack_trace/stack_trace.c
+++ b/ext/stack_trace/stack_trace.c
@@ -1,0 +1,29 @@
+#include <ruby.h>
+
+#ifdef __has_include
+  #if __has_include(<uuid/uuid.h>)
+    #define HAS_UUID 1
+    #include <uuid/uuid.h>
+  #endif
+#endif
+
+#ifdef HAS_UUID
+  static VALUE rb_uuid(VALUE self) {
+    uuid_t binuuid;
+    uuid_generate_random(binuuid);
+    char uuid[37];
+    uuid_unparse(binuuid, uuid);
+    VALUE rb_uuid = rb_str_new(uuid, 36);
+
+    return rb_uuid;
+  }
+#endif
+
+void Init_stack_trace() {
+  VALUE mainModule = rb_const_get(rb_cObject, rb_intern("StackTrace"));
+  VALUE utilsModule = rb_const_get(mainModule, rb_intern("Utils"));
+
+  #ifdef HAS_UUID
+    rb_define_singleton_method(utilsModule, "uuid", rb_uuid, 0);
+  #endif
+}

--- a/lib/stack_trace/trace.rb
+++ b/lib/stack_trace/trace.rb
@@ -1,7 +1,5 @@
 # frozen-string-literal: true
 
-require "securerandom"
-
 module StackTrace
   class Trace
     include Presenter
@@ -44,7 +42,7 @@ module StackTrace
     attr_reader :uuid, :spans
 
     def initialize
-      @uuid = SecureRandom.uuid
+      @uuid = Utils.uuid
       @spans = []
     end
 

--- a/lib/stack_trace/utils.rb
+++ b/lib/stack_trace/utils.rb
@@ -1,6 +1,7 @@
 # frozen-string-literal: true
 
 require "objspace"
+require "securerandom"
 
 module StackTrace
   class Utils
@@ -13,6 +14,10 @@ module StackTrace
         return {} unless StackTrace.configuration.trace_memory
 
         ObjectSpace.count_objects
+      end
+
+      def uuid
+        SecureRandom.uuid
       end
     end
   end

--- a/stack_trace.gemspec
+++ b/stack_trace.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
+
+  spec.extensions    = %w[ext/stack_trace/extconf.rb]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -29,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.13.0"
 end


### PR DESCRIPTION
This speeds up the generation of UUIDv4 if the required library is available in the system.

Note: The native extension won't be enabled by default and needs to be required by `require "stack_trace/native_extensions/stack_trace"`.